### PR TITLE
Fixes

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ModMetaData>
 	<name>Extended Storage</name>	
-	<targetVersion>1.0.2059</targetVersion>
+	<supportedVersions>
+		<li>1.0</li>
+	</supportedVersions>
 	<author>(see description)</author>
 	<description xml:whitespace="preserve">Adds additional storage buildings that multi stack items. Auto sort by Fluffy, Harmony by spdskatr
 

--- a/Defs/ThingDefs/Storage/Storage_Basket.xml
+++ b/Defs/ThingDefs/Storage/Storage_Basket.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-  <ThingDef Name="BuildingBase" Abstract="True">
+  <ThingDef Name="ESBuildingBase" Abstract="True">
     <category>Building</category>
     <thingClass>Building</thingClass>
     <soundImpactDefault>BulletImpact_Metal</soundImpactDefault>
@@ -14,7 +14,7 @@
     <drawGUIOverlay>true</drawGUIOverlay>
   </ThingDef>
 
-  <ThingDef Name="FurnitureBase" ParentName="BuildingBase" Abstract="True">
+  <ThingDef Name="ESFurnitureBase" ParentName="ESBuildingBase" Abstract="True">
     <designationCategory>Furniture</designationCategory>
     <minifiedDef>MinifiedThing</minifiedDef>
     <statBases>
@@ -32,7 +32,7 @@
   </ThingDef>
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_Basket</defName>
     <label>Food Basket</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_FabricHamper.xml
+++ b/Defs/ThingDefs/Storage/Storage_FabricHamper.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_FabricHamper</defName>
     <label>Fabric Hamper</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_FreezerChest.xml.bak
+++ b/Defs/ThingDefs/Storage/Storage_FreezerChest.xml.bak
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ExtendedStorage.ESdef ParentName="FurnitureBase">
+  <ExtendedStorage.ESdef ParentName="ESFurnitureBase">
     <defName>Freezer_Chest</defName>
     <label>Freezer chest</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_HazMatContainer.xml
+++ b/Defs/ThingDefs/Storage/Storage_HazMatContainer.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_HazMatContainer</defName>
     <label>HazMat Container</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_Locker.xml
+++ b/Defs/ThingDefs/Storage/Storage_Locker.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_Locker</defName>
     <label>Clothing Rack</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_MedicineCabinet.xml
+++ b/Defs/ThingDefs/Storage/Storage_MedicineCabinet.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_MedicineCabinet</defName>
     <label>Medicine Cabinet</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_Skip.xml
+++ b/Defs/ThingDefs/Storage/Storage_Skip.xml
@@ -4,7 +4,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_Skip</defName>
     <label>Skip</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_TrayRack.xml
+++ b/Defs/ThingDefs/Storage/Storage_TrayRack.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_TrayRack</defName>
     <label>Tray rack</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>

--- a/Defs/ThingDefs/Storage/Storage_WoodenPallet.xml
+++ b/Defs/ThingDefs/Storage/Storage_WoodenPallet.xml
@@ -3,7 +3,7 @@
 
   <!--============================== Storage ===========================-->
 
-  <ThingDef ParentName="FurnitureBase">
+  <ThingDef ParentName="ESFurnitureBase">
     <defName>Storage_WoodenPallet</defName>
     <label>Pallet</label>
     <thingClass>ExtendedStorage.Building_ExtendedStorage</thingClass>


### PR DESCRIPTION
- Compatability Fix, changing BuildingBase and FurnitureBase to ESBuildingBase and ESFurnitureBase.

This fixes any potential issues caused by dirty edits (unnecessary overwrites) to vanilla files. Fixes the known issue of furniture in other mods having quality labels.

- Updated versioning to recognise the new method. No more yellow warning error in the log, yay!